### PR TITLE
OPS-2175: migrating usage of request and request-promise to axios

### DIFF
--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -132,30 +132,29 @@ const downloadFlywaySource = exports.downloadFlywaySource = source => {
     (0, _axios2.default)({
       method: 'get',
       url: source.url,
-      // ensures the response is returned as a raw buffer
-      responseType: 'arraybuffer',
+      // ensures the response is returned as a stream
+      responseType: 'stream',
       proxy: proxyUrl ? {
         host: new URL(proxyUrl).hostname,
         port: new URL(proxyUrl).port
       } : false,
       headers: {
         'User-Agent': env.npm_config_user_agent || 'axios'
-      },
-      onDownloadProgress: progressEvent => {
-        if (!progressBar.total) {
-          // set total on first progress event
-          progressBar.total = progressEvent.total;
-        }
-
-        // how much data we have transferred so far
-        progressBar.curr = progressEvent.loaded;
-        progressBar.tick();
       }
     }).then(response => {
+      // set total on first progress event
       const totalLength = response.headers['content-length'];
+
+      if (totalLength) {
+        progressBar.total = parseInt(totalLength, 10);
+      }
 
       // write downloaded file data to disk
       const writer = _fsExtra2.default.createWriteStream(source.filename);
+      response.data.on('data', chunk => {
+        // update progress bar based on how much data we have transferred so far
+        progressBar.tick(chunk.length);
+      });
       response.data.pipe(writer);
 
       writer.on('finish', () => {

--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -55,7 +55,7 @@ const readDotFlywayFile = () => {
  */
 const getReleaseSource = exports.getReleaseSource = () => _axios2.default.get(`${repoBaseUrl}/maven-metadata.xml`).then(response => {
   let releaseRegularExp = new RegExp("<release>(.+)</release>");
-  let releaseVersion = readDotFlywayFile() || response.match(releaseRegularExp)[1];
+  let releaseVersion = readDotFlywayFile() || response.data.match(releaseRegularExp)[1];
 
   // console.log("getReleaseSource releaseVersion -> ", releaseVersion);
   let sources = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,21 @@
 {
   "name": "@freewillpbc/flywaydb-cli",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@freewillpbc/flywaydb-cli",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "axios": "^1.7.7",
         "extract-zip": "^2.0.1",
         "filesize": "^10.1.0",
         "fs-extra": "^11.1.1",
         "progress": "^2.0.3",
-        "request": "^2.88.2",
-        "request-progress": "^3.0.0",
-        "request-promise": "^4.2.6"
+        "request-progress": "^3.0.0"
       },
       "bin": {
         "flyway": "bin/flyway",
@@ -140,6 +139,8 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -394,20 +395,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.4",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -431,7 +418,8 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -598,16 +586,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
-    },
-    "node_modules/aws4": {
-      "version": "1.8.0",
-      "license": "MIT"
     },
     "node_modules/babel-cli": {
       "version": "6.26.0",
@@ -1370,13 +1357,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -1398,6 +1378,7 @@
     },
     "node_modules/bluebird": {
       "version": "3.5.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/boxen": {
@@ -1697,10 +1678,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "license": "Apache-2.0"
     },
     "node_modules/chalk": {
       "version": "1.1.3",
@@ -2035,8 +2012,9 @@
       "dev": true
     },
     "node_modules/combined-stream": {
-      "version": "1.0.7",
-      "license": "MIT",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2172,6 +2150,7 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/create-error-class": {
@@ -2215,16 +2194,6 @@
       "dependencies": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/date-time": {
@@ -2379,7 +2348,8 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2440,14 +2410,6 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
       "integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==",
       "dev": true
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/empower-core": {
       "version": "0.6.2",
@@ -3174,10 +3136,6 @@
       "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
       "dev": true
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "license": "MIT"
-    },
     "node_modules/extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -3269,21 +3227,18 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.0.0",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -3432,6 +3387,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -3462,23 +3436,17 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/form-data": {
-      "version": "2.3.3",
-      "license": "MIT",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
       }
     },
     "node_modules/formatio": {
@@ -3645,13 +3613,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3814,24 +3775,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/has": {
       "version": "1.0.4",
@@ -4031,19 +3974,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
     },
     "node_modules/hullabaloo-config-manager": {
       "version": "1.1.1",
@@ -4855,10 +4785,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/is-url": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
@@ -4915,10 +4841,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "license": "MIT"
     },
     "node_modules/jest-diff": {
       "version": "19.0.0",
@@ -5026,10 +4948,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -5045,12 +4963,11 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
-    "node_modules/json-schema": {
-      "version": "0.2.3"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-stable-stringify": {
       "version": "1.0.2",
@@ -5063,10 +4980,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "0.5.1",
@@ -5104,19 +5017,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.1",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -5226,7 +5126,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -5591,17 +5492,19 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.37.0",
-      "license": "MIT",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.21",
-      "license": "MIT",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dependencies": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -7765,13 +7668,6 @@
         "wrap-ansi": "^2.0.0"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8263,10 +8159,6 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
     "node_modules/pinkie": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
@@ -8552,15 +8444,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
       "dev": true
-    },
-    "node_modules/psl": {
-      "version": "1.1.31",
-      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -8573,16 +8466,11 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.2",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/queue-microtask": {
@@ -9234,75 +9122,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
       "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
       "dependencies": {
         "throttleit": "^1.0.0"
-      }
-    },
-    "node_modules/request-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
-      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
-      "deprecated": "request-promise has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "bluebird": "^3.5.0",
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
       }
     },
     "node_modules/require-precompiled": {
@@ -9482,6 +9307,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-regex": {
@@ -9506,10 +9332,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "license": "MIT"
     },
     "node_modules/samsam": {
       "version": "1.3.0",
@@ -9905,29 +9727,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "node_modules/sshpk": {
-      "version": "1.16.1",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-utils": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.5.tgz",
@@ -10052,13 +9851,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
       "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "license": "ISC",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10490,18 +10282,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -10519,20 +10299,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "license": "Unlicense"
     },
     "node_modules/type": {
       "version": "1.2.0",
@@ -10835,7 +10601,9 @@
     },
     "node_modules/uri-js": {
       "version": "4.2.2",
+      "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -10886,13 +10654,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "3.3.2",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/v8flags": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
@@ -10925,18 +10686,6 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/which-boxed-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "extract-zip": "^2.0.1",
         "filesize": "^10.1.0",
         "fs-extra": "^11.1.1",
-        "progress": "^2.0.3",
-        "request-progress": "^3.0.0"
+        "progress": "^2.0.3"
       },
       "bin": {
         "flyway": "bin/flyway",
@@ -9122,14 +9121,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/request-progress": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
-      "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
-      "dependencies": {
-        "throttleit": "^1.0.0"
-      }
-    },
     "node_modules/require-precompiled": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
@@ -10117,10 +10108,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
-    },
-    "node_modules/throttleit": {
-      "version": "1.0.0",
-      "license": "MIT"
     },
     "node_modules/through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "extract-zip": "^2.0.1",
     "filesize": "^10.1.0",
     "fs-extra": "^11.1.1",
-    "progress": "^2.0.3",
-    "request-progress": "^3.0.0"
+    "progress": "^2.0.3"
   },
   "devDependencies": {
     "@ava/babel-preset-stage-4": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freewillpbc/flywaydb-cli",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Install latest flywaydb-cli as a node module",
   "main": "dist/installer.js",
   "bin": {
@@ -35,13 +35,12 @@
   },
   "homepage": "https://github.com/freewillpbc/flywaydb-cli#readme",
   "dependencies": {
+    "axios": "^1.7.7",
     "extract-zip": "^2.0.1",
     "filesize": "^10.1.0",
     "fs-extra": "^11.1.1",
     "progress": "^2.0.3",
-    "request": "^2.88.2",
-    "request-progress": "^3.0.0",
-    "request-promise": "^4.2.6"
+    "request-progress": "^3.0.0"
   },
   "devDependencies": {
     "@ava/babel-preset-stage-4": "^1.0.0",

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -36,7 +36,7 @@ export const getReleaseSource = () =>
   axios.get(`${repoBaseUrl}/maven-metadata.xml`).then(response => {
     let releaseRegularExp = new RegExp("<release>(.+)</release>");
     let releaseVersion =
-      readDotFlywayFile() || response.match(releaseRegularExp)[1];
+      readDotFlywayFile() || response.data.match(releaseRegularExp)[1];
 
     // console.log("getReleaseSource releaseVersion -> ", releaseVersion);
     let sources = {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,13 +1,11 @@
 import os from "os";
 import fs from "fs-extra";
 import path from "path";
-import request from "request";
-import rp from "request-promise";
-import requestProgress from "request-progress";
 import ProgressBar from "progress";
 import extractZip from "extract-zip";
 import { spawn } from "child_process";
 import { filesize } from "filesize";
+import axios from 'axios'
 const env = process.env;
 
 const repoBaseUrl =
@@ -35,9 +33,7 @@ const readDotFlywayFile = () => {
  * @returns sources[os.platform()]
  */
 export const getReleaseSource = () =>
-  rp({
-    uri: `${repoBaseUrl}/maven-metadata.xml`
-  }).then(response => {
+  axios.get(`${repoBaseUrl}/maven-metadata.xml`).then(response => {
     let releaseRegularExp = new RegExp("<release>(.+)</release>");
     let releaseVersion =
       readDotFlywayFile() || response.match(releaseRegularExp)[1];
@@ -114,55 +110,65 @@ export const downloadFlywaySource = source => {
       env.npm_config_https_proxy ||
       env.npm_config_http_proxy ||
       env.npm_config_proxy;
-    let downloadOptions = {
-      uri: source.url,
-      encoding: null, // Get response as a buffer
-      followRedirect: true,
-      headers: {
-        "User-Agent": env.npm_config_user_agent
-      },
-      strictSSL: true,
+
+    const progressBar = new ProgressBar("  [:bar] :percent :etas", {
+      width: 40,
+      total: 0, // Initial total set to 0; will update on first progress event
+    });
+
+    // axios by default enforces strict SSL validation
+    // axios by default automatically follows redirect
+    axios({
+      method: 'get',
+      url: source.url,
+      // ensures the response is returned as a raw buffer
+      responseType: 'arraybuffer',
       proxy: proxyUrl
-    };
-    let consoleDownloadBar;
+        ? {
+          host: new URL(proxyUrl).hostname,
+          port: new URL(proxyUrl).port,
+        }
+        : false,
+      headers: {
+        'User-Agent': env.npm_config_user_agent || 'axios',
+      },
+      onDownloadProgress: (progressEvent) => {
+        if (!progressBar.total) {
+          // set total on first progress event
+          progressBar.total = progressEvent.total;
+        }
 
-    requestProgress(
-      request(downloadOptions, (error, response, body) => {
-        if (!error && response.statusCode === 200) {
-          fs.writeFileSync(source.filename, body);
+        // how much data we have transferred so far
+        progressBar.curr = progressEvent.loaded;
+        progressBar.tick();
+      },
+    }).then(response => {
+      const totalLength = response.headers['content-length'];
 
-          console.log(`\nReceived ${filesize(body.length)} total.`);
+      // write downloaded file data to disk
+      const writer = fs.createWriteStream(source.filename);
+      response.data.pipe(writer);
 
-          resolve(source.filename);
-        } else if (response) {
-          console.error(`
+      writer.on('finish', () => {
+        console.log(`\nReceived ${filesize(totalLength)} total.`);
+        resolve(source.filename);
+      });
+
+      writer.on('error', err => {
+        console.error("Error writing file: ", err);
+        reject(err);
+      });
+    }).catch(err => {
+      console.error(`
         Error requesting source.
-        Status: ${response.statusCode}
-        Request options: ${JSON.stringify(downloadOptions, null, 2)}
-        Response headers: ${JSON.stringify(response.headers, null, 2)}
+        URL: ${source.url}
+        Proxy URL: ${proxyUrl || 'none'}
+        Error: ${err.message}
         Make sure your network and proxy settings are correct.
 
-        If you continue to have issues, please report this full log at https://github.com/sgraham/flywaydb-cli`);
-          process.exit(1);
-        } else {
-          console.error("Error downloading : ", error);
-          process.exit(1);
-        }
-      })
-    ).on("progress", state => {
-      try {
-        if (!consoleDownloadBar) {
-          consoleDownloadBar = new ProgressBar("  [:bar] :percent", {
-            total: state.size.total,
-            width: 40
-          });
-        }
-
-        consoleDownloadBar.curr = state.size.transferred;
-        consoleDownloadBar.tick();
-      } catch (e) {
-        console.log("error", e);
-      }
+        If you continue to have issues, please report this full log at https://github.com/sgraham/flywaydb-cli
+      `);
+      reject(err);
     });
   });
 };

--- a/test/getReleaseSource.test.js
+++ b/test/getReleaseSource.test.js
@@ -1,44 +1,29 @@
 import test from 'ava'
-import sinon from 'sinon'
-import rp from 'request-promise'
 import rewire from 'rewire'
 import { getReleaseSource } from '../src/utils'
+import axios from 'axios'
+
 let utils = rewire('../src/utils')
 let uri = `${utils.__get__('repoBaseUrl')}/maven-metadata.xml`
 
 test('get maven xml', async t => {
   t.plan(1)
-  const res = await rp({
-    uri,
-    resolveWithFullResponse: true
-  })
-    .then((response) => {
-      // Access response.statusCode, response.body etc.
-      return response
-    })
-
-  t.is(res.statusCode, 200)
+  const res = await axios.get(uri);
+  t.is(res.status, 200)
 })
 
 test('regex release element from xml', async t => {
   t.plan(1)
-  await rp({
-    uri
-  })
-    .then((response) => {
-      t.regex(response, new RegExp('<release>(.+)</release>'), 'success')
-    })
+  const res = await axios.get(uri);
+  t.regex(res.data, new RegExp('<release>(.+)</release>'), 'success')
 })
 
 test('release version is string', async t => {
   t.plan(1)
-  await rp({
-    uri
-  })
-    .then((response) => {
-      let releaseVersion = response.match(new RegExp('<release>(.+)</release>'))[1]
-      t.is(typeof releaseVersion, 'string')
-    })
+
+  const res = await axios.get(uri);
+  let releaseVersion = res.data.match(new RegExp('<release>(.+)</release>'))[1];
+  t.is(typeof releaseVersion, 'string');
 })
 
 test('callback is object', async t => {


### PR DESCRIPTION
[OPS-2175](https://freewill.atlassian.net/browse/OPS-2175)

## How did you implement it
moving all usage of `request` and `request-promise` (and subsequently `request-progress`) to use `axios` instead. 

`request` and `request-promise` are prone to prototype pollution vulnerability from versions of `tough-cookie` older than 4.1.3 (more info in ticket)

[OPS-2175]: https://freewill.atlassian.net/browse/OPS-2175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## How can we verify it
`getReleaseSource` and `downloadFlywaySource` are called when we run `npm run install` in the flyway project (after building with our new changes of course). `getReleaseSource` should return the correct data from the Maven repository and is the first step in `npm run install` command. `downloadFlywaySource` is the second step in `npm run install` command and will save a file to your machine after success. Here are ss's of running `npm run install` locally (same output as when we used request library, and also got verbose error logging as expected when I had errors in my code!):

in the middle, we can see the progress bar working as intended:
![image](https://github.com/user-attachments/assets/88220b52-edbc-4408-8057-43ba0b2d2137)

when completed:
![image](https://github.com/user-attachments/assets/28ba04da-fdd8-46b8-8f7a-35abd7474c68)

- test the behavior across different platforms (win32, linux, darwin, and arm64) to confirm no regression
  - how might I do this?